### PR TITLE
add excluded options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,3 @@ as well as a set of standalone documentation files.
 The documentation is extracted by parsing your Go source using
 [Swag](https://github.com/swaggo/swag). Please refer to the documentation
 there for how to add the proper directives to your source code.
-
-Note that this project uses an embedded copy of the swag project, stripped
-down to the parts needed by this project. This was done to get around an
-issue with swag indirectly depending upon a non-existent package due to an
-upstream tag being removed. At some point in the future after this has been
-resolved, I may revert this change back.

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	cl.NewGeneralOption(&title).SetSingle('t').SetName("title").SetArg("text").SetUsage("The title for the HTML page. If unset, defaults to the base name")
 	cl.NewGeneralOption(&serverURL).SetSingle('u').SetName("url").SetArg("url").SetUsage("An additional server URL")
 	cl.NewGeneralOption(&embedded).SetSingle('e').SetName("embedded").SetUsage("When set, embeds the spec directly in the html")
-	cl.NewGeneralOption(&exclude).SetSingle('x').SetName("exclude").SetUsage("Exclude directories and files when searching, comma separated")
+	cl.NewGeneralOption(&exclude).SetSingle('x').SetName("exclude").SetUsage("Exclude directories and files when searching. Example for multiple: -x file1 -x file2")
 	cl.Parse(os.Args[1:])
 	if title == "" {
 		title = baseName

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/richardwilkes/toolbox/atexit"
 	"github.com/richardwilkes/toolbox/cmdline"
@@ -32,7 +33,7 @@ func main() {
 	title := ""
 	serverURL := ""
 	embedded := false
-	exclude := ""
+	var exclude []string
 	cl.NewGeneralOption(&searchDir).SetSingle('s').SetName("search").SetArg("dir").SetUsage("The directory root to search for documentation directives")
 	cl.NewGeneralOption(&mainAPIFile).SetSingle('m').SetName("main").SetArg("file").SetUsage("The Go file to search for the main documentation directives")
 	cl.NewGeneralOption(&destDir).SetSingle('o').SetName("output").SetArg("dir").SetUsage("The destination directory to write the documentation files to")
@@ -51,14 +52,14 @@ func main() {
 	atexit.Exit(0)
 }
 
-func generate(searchDir, mainAPIFile, destDir, baseName, title, serverURL, markdownFileDir, exclude string, maxDependencyDepth int, embedded bool) error {
+func generate(searchDir, mainAPIFile, destDir, baseName, title, serverURL, markdownFileDir string, exclude []string, maxDependencyDepth int, embedded bool) error {
 	if err := os.MkdirAll(filepath.Join(destDir, apiDir), 0o755); err != nil { //nolint:gosec // Yes, I want these permissions
 		return errs.Wrap(err)
 	}
 
 	opts := make([]func(*swag.Parser), 0)
-	if exclude != "" {
-		opts = append(opts, swag.SetExcludedDirsAndFiles(exclude))
+	if len(exclude) != 0 {
+		opts = append(opts, swag.SetExcludedDirsAndFiles(strings.Join(exclude, ",")))
 	}
 	if markdownFileDir != "" {
 		opts = append(opts, swag.SetMarkdownFileDirectory(markdownFileDir))


### PR DESCRIPTION
hi, this is to accept the exclude directory/files option that's exposed in the swag cli.

use case:
we have an api that will be used both for internal teams and external partners.  we'd like to be able to host 2 swagger docs/paths
- external path: `/swagger/external/api` and this would only show the documentation for endpoints that partners can use
- internal path: `/swagger/api` this would include all our endpoints and be viewable by internal teams

in order to do this, we'd need to split out the endpoints into different directories and exclude directories in the generated documentation.
